### PR TITLE
Improve MailingOut's Notification Field: Add Scrollable Wrapper for Long Notifications 

### DIFF
--- a/massmail/site/mailingoutadmin.py
+++ b/massmail/site/mailingoutadmin.py
@@ -110,7 +110,7 @@ class MailingOutAdmin(CrmModelAdmin):
         lines = report.count('\n') + 1 if report else 0
         content = linebreaksbr(report)
         style = (
-            "overflow:auto; max-height:200px; width:500px; "
+            "overflow:auto; max-height:200px;"
             "white-space:pre-wrap;"
         ) if lines >= 20 else "white-space:pre-wrap;"
         custom_scrollbar = (

--- a/massmail/site/mailingoutadmin.py
+++ b/massmail/site/mailingoutadmin.py
@@ -115,7 +115,7 @@ class MailingOutAdmin(CrmModelAdmin):
         ) if lines >= 20 else "white-space:pre-wrap;"
         custom_scrollbar = (
             "<style>"
-            "div.mailingout-scroll::-webkit-scrollbar {width:6px;}"
+            "div.mailingout-scroll::-webkit-scrollbar {width:10px;}"
             "div.mailingout-scroll::-webkit-scrollbar-thumb {background:#ccc; border-radius:3px;}"
             "</style>"
             if lines >= 20 else ""

--- a/massmail/site/mailingoutadmin.py
+++ b/massmail/site/mailingoutadmin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.conf import settings
 from django.contrib import messages
-from django.template.defaultfilters import linebreaks
+from django.template.defaultfilters import linebreaksbr
 from django.utils import timezone
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
@@ -106,7 +106,24 @@ class MailingOutAdmin(CrmModelAdmin):
     @staticmethod
     @admin.display(description=_('notification'))
     def notification(instance):
-        return mark_safe(linebreaks(instance.report))
+        report = instance.report or ""
+        lines = report.count('\n') + 1 if report else 0
+        content = linebreaksbr(report)
+        style = (
+            "overflow:auto; max-height:200px; width:500px; "
+            "white-space:pre-wrap;"
+        ) if lines >= 20 else "white-space:pre-wrap;"
+        custom_scrollbar = (
+            "<style>"
+            "div.mailingout-scroll::-webkit-scrollbar {width:6px;}"
+            "div.mailingout-scroll::-webkit-scrollbar-thumb {background:#ccc; border-radius:3px;}"
+            "</style>"
+            if lines >= 20 else ""
+        )
+        div_class = "mailingout-scroll" if lines >= 20 else ""
+        return mark_safe(
+            f'{custom_scrollbar}<div class="{div_class}" style="{style}">{content}</div>'
+        )
     
     @staticmethod
     @admin.display(description=progress_safe_str)


### PR DESCRIPTION
**Description**  
This PR enhances the usability of the "notifications" field in the CRM mailing list admin(addresses and fixes the issue #213). If the notification (report) contains 20 or more lines, it is now displayed in a scrollable, fixed-height box . This prevents long error logs from cluttering the admin interface and improves readability for users/admins managing large mailings with many error messages. 