### PR TITLE
added region and district fields

### DIFF
--- a/crm/admin.py
+++ b/crm/admin.py
@@ -348,6 +348,8 @@ class RequestAdmin(requestadmin.RequestAdmin):
                     ('modified_by', 'ticket')
                 ]
             }),
+                                       'region',
+                                       'district',
         )
 
 
@@ -477,3 +479,4 @@ crm_site.register(Product, productadmin.ProductAdmin)
 crm_site.register(Request, requestadmin.RequestAdmin)
 crm_site.register(Shipment, ShipmentAdmin)
 crm_site.register(Tag, tagadmin.TagAdmin)
+

--- a/crm/admin.py
+++ b/crm/admin.py
@@ -106,7 +106,6 @@ class CompanyAdmin(companyadmin.CompanyAdmin):
                     'website',
                     'city_name',
                     ('city', 'country'),
-                    'region', 'district',
                     'address',
                 )
             }),
@@ -278,6 +277,7 @@ class LeadAdmin(leadadmin.LeadAdmin):
                     ('company_name', 'website'),
                     ('company_email', 'country'),
                     'address',
+                    'region', 'district'
                 )
             }),
             (_('Additional information'), {

--- a/crm/site/leadadmin.py
+++ b/crm/site/leadadmin.py
@@ -140,6 +140,8 @@ class LeadAdmin(CrmModelAdmin):
                     ('company_name', 'website'),
                     'company_email',
                     ('city', 'country'),
+                       'region',
+                       'district',
                     'address',
                     'type',
                     'industry'


### PR DESCRIPTION
Solves #264 
- [x] Branch: feature/add-region-district
- [x] This pull request adds the region and district fields to the Company contact details fieldsets section in the following classes:
```
crm.site.leadadmin.LeadAdmin

crm.admin.LeadAdmin
```
- Closes: Add the region and district fields to the 'Company contact details' fieldsets section in LeadAdmin classes.
```
Ran 182 tests in 17.579s

OK (skipped=4)
```
