### PR TITLE
fix: Hide Duplicate and Case checkboxes if Deal exists #307

### DIFF
--- a/crm/site/requestadmin.py
+++ b/crm/site/requestadmin.py
@@ -192,12 +192,21 @@ class RequestAdmin(CrmModelAdmin):
 
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
+        
+        if obj and getattr(obj, "deal", None):
+            if "duplicate" in form.base_fields:
+                form.base_fields["duplicate"].widget = admin.widgets.AdminHiddenInput()
+            if "case" in form.base_fields:
+                form.base_fields["case"].widget = admin.widgets.AdminHiddenInput()
+
         if request.method == "POST" and '_create-deal' in request.POST:
             department_id = request.user.department_id
             works_globally = Department.objects.get(
-                id=department_id).works_globally
+                id=department_id
+            ).works_globally
             if works_globally:
                 form.country_must_be_specified = True
+
         return form
 
     def get_changeform_initial_data(self, request):


### PR DESCRIPTION
This update ensures that the Duplicate and Case checkboxes on a Request in the admin panel are hidden if a Deal has already been created for that Request. This prevents accidental duplicate or case entries. All other fields and functionality in RequestAdmin remain unchanged.