### PR TITLE
Implements the requested enhancements described in issue #307 and Resolves issues found in PR #318

### DIFF
--- a/crm/site/requestadmin.py
+++ b/crm/site/requestadmin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.core.handlers.wsgi import WSGIRequest
+from django.forms.widgets import HiddenInput
 from django.http import HttpResponseRedirect
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
@@ -192,12 +193,21 @@ class RequestAdmin(CrmModelAdmin):
 
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
+        
+        if obj and getattr(obj, "deal", None):
+            if "duplicate" in form.base_fields:
+                form.base_fields["duplicate"].widget = HiddenInput()
+            if "case" in form.base_fields:
+                form.base_fields["case"].widget = HiddenInput()
+
         if request.method == "POST" and '_create-deal' in request.POST:
             department_id = request.user.department_id
             works_globally = Department.objects.get(
-                id=department_id).works_globally
+                id=department_id
+            ).works_globally
             if works_globally:
                 form.country_must_be_specified = True
+
         return form
 
     def get_changeform_initial_data(self, request):


### PR DESCRIPTION
## Summary
Implements the requested enhancements described in issue #307 and Resolves issues found in PR #318

## Description 
* In the `get_form` method of `RequestAdmin`, the `duplicate` and `case` fields are now set to use `HiddenInput` widgets when the object being edited has a related `deal`. This hides these fields from the admin form in relevant cases.
* Added import of `HiddenInput` from `django.forms.widgets` to support the new behavior.
## Pull Request Checklist

## Checklist
- [ ] Tests passed.
    ```cmd
      python manage.py test tests/ --noinput
    ```
- [x] No testing required.
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch. Don't request your master!
- [x] A descriptive title and description of the changes made are provided.
- [x] Submit one item per pull request. This eases reviewing and speeds up merging.
- [ ] All changed files cannot be split into multiple pull requests (must be in one PR)
- [x] The documentation is up-to-date

## When applicable

- [x] The issue number is provided in the description or title of the pull request.
- [x] Does this close the issue mentioned?
- [ ] Screenshots of the results are provided.
- [ ] Additional tests have been written.

