### PR TITLE
Fix TheFile.__str__ to always return the filename

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -1,5 +1,3 @@
-import os
-
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -211,7 +209,8 @@ class TheFile(models.Model):
 
     def __str__(self):
         if self.file.name:
-            return self.file.name.split(os.sep)[-1]
+            return self.file.name.replace("\\", "/").rsplit("/", 1)[-1]
+
         return 'File'
 
     def delete(self, *args, **kwargs):


### PR DESCRIPTION
Closes #407

## Summary

Updated `TheFile.__str__()` to always return only the filename (basename), regardless of whether the stored file path uses Windows (`\`) or POSIX (`/`) path separators.

## Testing

- `python manage.py test tests/ --noinput` ⚠️ The full suite has pre-existing failures/errors that were present before this change and are unrelated to this PR.

## Pull Request Checklist

- [ ] Tests passed.
    ```cmd
    python manage.py test tests/ --noinput
    ```
- [ ] No testing required.
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch. Don't request your master!
- [x] A descriptive title and description of the changes made are provided.
- [x] Submit one item per pull request. This eases reviewing and speeds up merging.
- [x] All changed files cannot be split into multiple pull requests (must be in one PR)
- [x] The documentation is up-to-date

## When applicable

- [x] The issue number is provided in the description or title of the pull request.
- [x] Does this close the issue mentioned?
- [ ] Screenshots of the results are provided.
- [ ] Additional tests have been written.