### PR TITLE
fix(admin): hide attachment icon on TransactionQualityEvent inlines when no files exist

### DIFF
--- a/quality/site/transactionqualityeventinline.py
+++ b/quality/site/transactionqualityeventinline.py
@@ -31,7 +31,6 @@ class TransactionQualityEventInline(CrmStackedInline):
             'fields': (
                 ('signal', 'weight'),
                 'details',
-                'file_links',
             )
         }),
     )
@@ -41,6 +40,7 @@ class TransactionQualityEventInline(CrmStackedInline):
     name_plural = model._meta.verbose_name_plural
     readonly_fields = ('file_links',)
     show_change_link = True
+    template = 'admin/quality/transactionqualityevent/stacked.html'
     verbose_name_plural = f'{icon} {name_plural}'
 
     # -- ModelAdmin methods -- #
@@ -55,6 +55,8 @@ class TransactionQualityEventInline(CrmStackedInline):
 
     @admin.display(description=SAFE_ATTACH_FILE_ICON)
     def file_links(self, obj):
+        if obj is None:
+            return ''
         files = obj.files.all()
         if files:
             return get_file_links(files)

--- a/quality/templates/admin/quality/transactionqualityevent/stacked.html
+++ b/quality/templates/admin/quality/transactionqualityevent/stacked.html
@@ -1,0 +1,50 @@
+{% load i18n admin_urls quality_inline %}{# Based on Django admin/edit_inline/stacked.html #}
+<div class="js-inline-admin-formset inline-group"
+     id="{{ inline_admin_formset.formset.prefix }}-group"
+     data-inline-type="stacked"
+     data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
+<fieldset class="module {{ inline_admin_formset.classes }}" aria-labelledby="{{ inline_admin_formset.formset.prefix }}-heading">
+  {% if inline_admin_formset.is_collapsible %}<details><summary>{% endif %}
+  <h2 id="{{ inline_admin_formset.formset.prefix }}-heading" class="inline-heading">
+  {% if inline_admin_formset.formset.max_num == 1 %}
+    {{ inline_admin_formset.opts.verbose_name|capfirst }}
+  {% else %}
+    {{ inline_admin_formset.opts.verbose_name_plural|capfirst }}
+  {% endif %}
+  </h2>
+  {% if inline_admin_formset.is_collapsible %}</summary>{% endif %}
+{{ inline_admin_formset.formset.management_form }}
+{{ inline_admin_formset.formset.non_form_errors }}
+
+{% for inline_admin_form in inline_admin_formset %}<div class="inline-related{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form last-related{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
+  <h3><b>{{ inline_admin_formset.opts.verbose_name|capfirst }}:</b> <span class="inline_label">{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %} <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}
+{% else %}#{{ forloop.counter }}{% endif %}</span>
+      {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% translate "View on site" %}</a>{% endif %}
+    {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission and inline_admin_form.original %}<span class="delete">{{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}</span>{% endif %}
+  </h3>
+  {% if inline_admin_form.form.non_field_errors %}{{ inline_admin_form.form.non_field_errors }}{% endif %}
+
+  {% with parent_counter=forloop.counter0 %}
+    {% for fieldset in inline_admin_form %}
+      {% include "admin/includes/fieldset.html" with heading_level=4 prefix=fieldset.formset.prefix id_prefix=parent_counter id_suffix=forloop.counter0 %}
+    {% endfor %}
+  {% endwith %}
+
+  {# Render file attachments row only when files exist #}
+  {% with links=inline_admin_form|file_links_for %}
+    {% if links %}
+    <div class="form-row">
+      <div>
+        <label>{% attach_icon %}</label>
+        <div class="readonly">{{ links }}</div>
+      </div>
+    </div>
+    {% endif %}
+  {% endwith %}
+
+  {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+  {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
+</div>{% endfor %}
+  {% if inline_admin_formset.is_collapsible %}</details>{% endif %}
+</fieldset>
+</div>

--- a/quality/templatetags/quality_inline.py
+++ b/quality/templatetags/quality_inline.py
@@ -1,0 +1,21 @@
+from django import template
+
+from common.utils.helpers import SAFE_ATTACH_FILE_ICON
+
+register = template.Library()
+
+
+@register.filter
+def file_links_for(inline_admin_form):
+    """Returns rendered file links for an inline form, or empty string."""
+    if not inline_admin_form.original:
+        return ''
+    return inline_admin_form.model_admin.file_links(
+        inline_admin_form.original
+    )
+
+
+@register.simple_tag
+def attach_icon():
+    """Returns the paperclip icon used for file attachments."""
+    return SAFE_ATTACH_FILE_ICON


### PR DESCRIPTION
## Related Issue
Closes : https://github.com/DjangoCRM/django-crm/issues/454

---

## Problem

The attachment (paperclip) icon appears in every `TransactionQualityEvent` inline on the Deal change page, even when no files are attached.

This results in:

- Empty new inline forms still showing an attachment indicator
- Existing `TransactionQualityEvent` entries without files still rendering a blank attachment row + icon
- Confusing UI where the presence of the icon incorrectly implies files exist

---

## Root Cause

`file_links` was defined as a readonly field inside the inline `fieldsets`.

Django’s admin `fieldset.html` always renders field labels regardless of whether the field content is empty, and inline instances do not provide a per-object hook to conditionally exclude a single field at the fieldset level.

As a result, the icon markup is always rendered even when there is no underlying file data.

---

## Solution

This PR moves attachment rendering logic out of Django’s fieldset system and into the template layer where per-inline instance control is possible.

---

### 1. Inline changes

**File:** `quality/site/transactionqualityeventinline.py`

- Removed `file_links` from `fieldsets`
- Switched to a custom `stacked.html` template override
- Added defensive guard in `file_links()` (`obj is None` check)

---

### 2. Template tags

**File:** `quality/templatetags/quality_inline.py`

- Added `file_links_for` filter:
  - Returns rendered file links only when:
    - inline has a saved object
    - object has files
  - Otherwise returns empty string
- Added `attach_icon` simple tag:
  - Exposes `SAFE_ATTACH_FILE_ICON` constant to templates
  - Keeps icon definition centralized and reusable

---

### 3. Admin template override

**File:** `quality/templates/admin/quality/transactionqualityevent/stacked.html`

- Overrides default `admin/edit_inline/stacked.html`
- Conditionally renders attachment block only when `file_links_for` returns content
- Ensures each inline instance independently controls rendering
- Keeps markup ownership in template layer (not Python)

---

### 4. Package initialization

**File:** `quality/templatetags/__init__.py`

- Added to ensure Django recognizes the templatetags module

---
### 5. Tests passed:
- python manage.py test tests/ --noinput

## Behavior Changes

| Scenario | Before | After |
|----------|--------|-------|
| New inline form | Paperclip shown | Hidden |
| Existing event (no files) | Paperclip shown | Hidden |
| Existing event (1+ files) | Paperclip shown + link | Same |
| Multiple files | Paperclip + list | Same |
| Mixed inline states | Incorrect rendering | Correct per-inline behavior |
| Other inlines | Unchanged | Unchanged |

---

## Design Decisions

- **Template-level control over fieldset logic**  
  Django admin fieldsets are object-level, not inline-instance-level, so conditional rendering must live in the template.

- **Filter returns data, not markup structure**  
  `file_links_for` returns only safe HTML output from `get_file_links()`. Structural markup remains in the template to preserve separation of concerns.

- **Centralized icon constant exposure**  
  `attach_icon` ensures icon markup is not duplicated across templates and remains maintainable.

---

## Impact

- No behavior changes outside `TransactionQualityEvent` inline
- No changes to list view or other admin components
- Improves UI clarity by only showing attachment affordance when files exist