### PR TITLE
Fix: scope message_preview to user's department (except Chief/Superuser)

### DIFF
--- a/massmail/views/message_previews.py
+++ b/massmail/views/message_previews.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse
 from django.template import RequestContext
 from django.template import Template
+from django.shortcuts import get_object_or_404
 
 from massmail.models import EmlMessage
 from settings.models import MassmailSettings
@@ -8,7 +9,17 @@ from settings.models import MassmailSettings
 
 def message_preview(request, message_id):
     
-    message = EmlMessage.objects.get(id=message_id)
+    if any((
+        request.user.is_superuser,
+        request.user.is_chief,
+    )):
+        message = get_object_or_404(EmlMessage, id=message_id)
+    else:
+        message = get_object_or_404(
+            EmlMessage,
+            id=message_id,
+            department_id=request.user.department_id
+        )
     signature = message.signature
     signature_content = signature.content if signature else ''
     content = f"""


### PR DESCRIPTION
Fixes a cross-department information disclosure in `massmail.views.message_previews.message_preview`.

The view fetched `EmlMessage.objects.get(id=message_id)` with no department scope, so any authenticated user could view another department's mass-mail campaign by iterating `message_id`. The admin changelist already scopes `EmlMessage` by department in `CrmModelAdmin.get_queryset`, so this view was the odd one out.

This mirrors that check: users see only `EmlMessage` rows in their own `department_id`, unless they're a Superuser or in the `chiefs` group. Uses `get_object_or_404` so an out-of-department id returns a 404 instead of leaking the object.

`signature_preview` in the same file is intentionally left untouched — reported separately and confirmed not to be a vulnerability.

Ref: GHSA-mj5m-8jhf-7xvh