### PR TITLE
Add copy action to the Email Accounts list

### DIFF
--- a/massmail/site/emailaccountadmin.py
+++ b/massmail/site/emailaccountadmin.py
@@ -1,9 +1,13 @@
 from django.contrib import admin
 from django.template.defaultfilters import linebreaks
+from django.urls import reverse
 from django.utils.formats import date_format
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
+from common.utils.helpers import CONTENT_COPY_ICON
+from common.utils.helpers import CONTENT_COPY_LINK
+from common.utils.helpers import COPY_STR
 from common.utils.helpers import SAFE_SUBJECT_ICON
 from crm.site.crmmodeladmin import CrmModelAdmin
 from crm.utils.admfilters import ByOwnerFilter
@@ -25,6 +29,26 @@ MAIN = _("main")
 MAIN_TITLE = _("Default email account for all customer correspondence")
 MASS_MAILING = _("mass mailing")
 MASS_MAILING_TITLE = _("Email account availability for mass mailing")
+COPIED_FIELDS = (
+    'name',
+    'massmail',
+    'do_import',
+    'email_host',
+    'imap_host',
+    'email_host_user',
+    'email_host_password',
+    'email_app_password',
+    'email_port',
+    'from_email',
+    'email_use_tls',
+    'email_use_ssl',
+    'email_imail_ssl_certfile',
+    'email_imail_ssl_keyfile',
+    'refresh_token',
+    'owner',
+    'co_owner',
+    'department',
+)
 
 
 class EmailAccountAdmin(CrmModelAdmin):
@@ -57,6 +81,23 @@ class EmailAccountAdmin(CrmModelAdmin):
     search_fields = ('name', "email_host", "email_host_user")
 
     # -- ModelAdmin methods -- #
+
+    def get_changeform_initial_data(self, request):
+        initial = super().get_changeform_initial_data(request)
+        email_account_id = request.GET.get('copy_email_account')
+        if email_account_id:
+            email_account = self.get_object(request, email_account_id)
+            if email_account:
+                for field in COPIED_FIELDS:
+                    initial[field] = getattr(email_account, field)
+                initial['main'] = False
+        return initial
+
+    def get_list_display(self, request):
+        list_display = list(super().get_list_display(request))
+        if self.has_add_permission(request):
+            list_display.append('content_copy')
+        return list_display
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
@@ -96,6 +137,15 @@ class EmailAccountAdmin(CrmModelAdmin):
                     qobj.remove_id(obj.pk)
 
     # -- ModelAdmin Callables -- #
+
+    @admin.display(description='')
+    def content_copy(self, obj):
+        url = reverse(
+            "site:massmail_emailaccount_add"
+        ) + f"?copy_email_account={obj.id}"
+        return mark_safe(
+            CONTENT_COPY_LINK.format(url, COPY_STR, CONTENT_COPY_ICON)
+        )
 
     @admin.display(description=SAFE_SUBJECT_ICON)
     def account(self, obj):

--- a/tests/massmail/test_email_account.py
+++ b/tests/massmail/test_email_account.py
@@ -1,0 +1,159 @@
+from django.contrib.auth.models import Permission
+from django.test import tag
+from django.urls import reverse
+
+from common.utils.helpers import get_department_id
+from common.utils.helpers import USER_MODEL
+from massmail.models import EmailAccount
+from tests.base_test_classes import BaseTestCase
+
+
+# python manage.py test tests.massmail.test_email_account --keepdb
+
+
+@tag('TestCase')
+class TestEmailAccountCopy(BaseTestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        users = USER_MODEL.objects.filter(
+            username__in=(
+                "Andrew.Manager.Global",
+                "Darian.Manager.Co-worker.Head.Global",
+            )
+        )
+        cls.owner = users.get(username="Andrew.Manager.Global")
+        cls.other_user = users.get(
+            username="Darian.Manager.Co-worker.Head.Global"
+        )
+        cls.owner.user_permissions.add(
+            Permission.objects.get(
+                codename='add_emailaccount',
+                content_type__app_label='massmail',
+            )
+        )
+        cls.account = EmailAccount.objects.create(
+            name='Primary account',
+            main=True,
+            massmail=True,
+            do_import=True,
+            email_host='smtp.example.com',
+            imap_host='imap.example.com',
+            email_host_user='andrew@example.com',
+            email_host_password='password',
+            email_app_password='app-password',
+            email_port=587,
+            from_email='sales@example.com',
+            email_use_tls=True,
+            email_imail_ssl_certfile='/certs/account.pem',
+            email_imail_ssl_keyfile='/certs/account.key',
+            refresh_token='refresh-token',
+            owner=cls.owner,
+            co_owner=cls.other_user,
+            department_id=get_department_id(cls.owner),
+            report='runtime report',
+            today_count=17,
+            start_incoming_uid=42,
+        )
+        cls.add_url = reverse("site:massmail_emailaccount_add")
+        cls.changelist_url = reverse(
+            "site:massmail_emailaccount_changelist"
+        )
+
+    def setUp(self):
+        self.client.force_login(self.owner)
+
+    def test_changelist_contains_copy_link(self):
+        response = self.client.get(self.changelist_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            f'{self.add_url}?copy_email_account={self.account.id}',
+        )
+
+    def test_changelist_hides_copy_link_without_add_permission(self):
+        account = EmailAccount.objects.create(
+            name='Read-only account',
+            email_host='smtp.readonly.example.com',
+            email_host_user='readonly@example.com',
+            email_host_password='password',
+            from_email='readonly@example.com',
+            owner=self.other_user,
+            department_id=get_department_id(self.other_user),
+        )
+        self.client.force_login(self.other_user)
+
+        response = self.client.get(self.changelist_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            f'{self.add_url}?copy_email_account={account.id}',
+        )
+
+    def test_copy_prefills_configuration_without_runtime_state(self):
+        response = self.client.get(
+            self.add_url,
+            {'copy_email_account': self.account.id},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        initial = response.context['adminform'].form.initial
+        self.assertEqual(initial['name'], self.account.name)
+        self.assertIs(initial['main'], False)
+        self.assertIs(initial['massmail'], True)
+        self.assertIs(initial['do_import'], True)
+        self.assertEqual(initial['email_host'], self.account.email_host)
+        self.assertEqual(initial['imap_host'], self.account.imap_host)
+        self.assertEqual(
+            initial['email_host_user'], self.account.email_host_user
+        )
+        self.assertEqual(
+            initial['email_host_password'],
+            self.account.email_host_password,
+        )
+        self.assertEqual(
+            initial['email_app_password'], self.account.email_app_password
+        )
+        self.assertEqual(initial['email_port'], self.account.email_port)
+        self.assertEqual(initial['from_email'], self.account.from_email)
+        self.assertIs(initial['email_use_tls'], True)
+        self.assertIs(initial['email_use_ssl'], False)
+        self.assertEqual(
+            initial['email_imail_ssl_certfile'],
+            self.account.email_imail_ssl_certfile,
+        )
+        self.assertEqual(
+            initial['email_imail_ssl_keyfile'],
+            self.account.email_imail_ssl_keyfile,
+        )
+        self.assertEqual(initial['refresh_token'], self.account.refresh_token)
+        self.assertEqual(initial['owner'], self.account.owner)
+        self.assertEqual(initial['co_owner'], self.account.co_owner)
+        self.assertEqual(initial['department'], self.account.department)
+        self.assertNotIn('report', initial)
+        self.assertNotIn('today_count', initial)
+        self.assertNotIn('start_incoming_uid', initial)
+
+    def test_copy_does_not_read_another_users_account(self):
+        inaccessible_account = EmailAccount.objects.create(
+            name='Other account',
+            email_host='smtp.other.example.com',
+            email_host_user='other@example.com',
+            email_host_password='password',
+            from_email='other@example.com',
+            owner=self.other_user,
+            department_id=get_department_id(self.other_user),
+        )
+
+        response = self.client.get(
+            self.add_url,
+            {'copy_email_account': inaccessible_account.id},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        initial = response.context['adminform'].form.initial
+        self.assertNotIn('name', initial)
+        self.assertEqual(initial['owner'], self.owner.id)


### PR DESCRIPTION
## Summary

- add a copy action beside Email Accounts for users with add permission
- prefill the add form from an account visible to the current user while leaving the new account non-main and excluding runtime state
- cover the copy link, permissions, initial values, and cross-owner access boundary

Closes #467

## Testing

```cmd
python manage.py test tests/ --noinput
```

341 tests passed, with 4 skipped.

## Pull Request Checklist

- [x] Tests passed.
- [x] This is a topic branch, not the default branch.
- [x] A descriptive title and description are provided.
- [x] This pull request contains one item.
- [x] The changed implementation and regression tests belong in the same pull request.
- [x] Documentation remains up-to-date; no user-facing documentation change is required.

## When applicable

- [x] The issue number is provided.
- [x] This closes the issue mentioned.
- [x] Additional tests have been written.
