### PR TITLE
Hide Create Deal button for duplicate requests (#471)

### DIFF
--- a/crm/templates/admin/crm/request/submit_line.html
+++ b/crm/templates/admin/crm/request/submit_line.html
@@ -10,7 +10,7 @@
     {% else %}
         <input type="submit" value="{% translate 'Activate' %}" name="_activate-case" >
     {% endif %}
-{% elif not original.deal and has_change_deal_perm %}
+{% elif not original.deal and has_change_deal_perm and not original.duplicate and not original.case %}
     <input type="submit" value="{% translate 'Create deal' %}" name="_create-deal" >
 {% endif %}
 {% if show_close %}


### PR DESCRIPTION
Fixes #471
Hides the "Create Deal" button on the Request edit page when the request is marked as duplicate, matching the existing behavior for incidents (`original.case`).
## Change
Single-line addition in `submit_line.html` — added `and not original.duplicate` to the existing button-visibility condition.
## Testing
Ran the full test suite locally — all 337 tests pass (`python manage.py test tests/ --noinput`).
## Screenshots
**Before (Duplicate unchecked):** "Create deal" button visible
**After (Duplicate checked):** "Create deal" button hidden

👉 Please review the [guidelines](https://github.com/DjangoCRM/django-crm/blob/main/CONTRIBUTING.md) for contributing to this repository.

## Pull Request Checklist

*Put an x in the boxes that apply.*

- [x] Tests passed.
    ```cmd
      python manage.py test tests/ --noinput
    ```
- [ ] No testing required.
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch. Don't request your master!
- [x] A descriptive title and description of the changes made are provided.
- [x] Submit one item per pull request. This eases reviewing and speeds up merging.
- [x] All changed files cannot be split into multiple pull requests (must be in one PR)
- [ ] The documentation is up-to-date

## When applicable

- [x] The issue number is provided in the description or title of the pull request.
- [x] Does this close the issue mentioned?
- [x] Screenshots of the results are provided.
- [ ] Additional tests have been written.

❤️ Thank you so much for your contribution to the Django CRM project!

**Before (Duplicate unchecked):** Create deal button visible
<img width="1351" height="646" alt="image" src="https://github.com/user-attachments/assets/88bbfe67-c4ca-497e-a100-e001eb442d58" />

**After (Duplicate checked):** Create deal button hidden
<img width="1351" height="647" alt="image" src="https://github.com/user-attachments/assets/51a593f6-25a1-41e2-b87a-99c8950d72cf" />
