### PR TITLE
Copy request website to new leads

### DIFF
--- a/crm/models/request.py
+++ b/crm/models/request.py
@@ -404,6 +404,7 @@ class Request(Base1):
             last_name=self.last_name,
             email=self.email,
             phone=self.phone,
+            website=self.website,
             company_name=self.company_name,
             lead_source=self.lead_source,
             country=self.country,

--- a/tests/crm/test_request_methods.py
+++ b/tests/crm/test_request_methods.py
@@ -177,11 +177,16 @@ class TestRequestMethods(BaseTestCase):
 
     def test_creation_new_lead(self):
         self.new_lead_request.owner = self.owner
+        self.new_lead_request.website = 'https://bruno.example.com'
         self.new_lead_request.get_or_create_contact_or_lead()
         msg = "Found the wrong contact"
         self.assertFalse(self.new_lead_request.contact, msg)
         msg = "New lead has not been created"
-        self.assertTrue(self.new_lead_request.lead, msg)         
+        self.assertTrue(self.new_lead_request.lead, msg)
+        self.assertEqual(
+            self.new_lead_request.lead.website,
+            self.new_lead_request.website,
+        )
         
     def test_creation_new_contact(self):
         new_contact_request = Request(


### PR DESCRIPTION
Copies the website from a Request to the new Lead created when no existing Lead or Company is identified. This keeps the existing matched-Company behavior, where the Company website remains authoritative.

Adds a regression assertion to the existing `test_creation_new_lead` test.

Fixes #481

## Testing

- `python manage.py test tests.crm.test_request_methods.TestRequestMethods.test_creation_new_lead --noinput --verbosity 2`
- `python manage.py check`
- Full suite: 342 tests with the same five pre-existing `mail.outbox` failures and four skips on the base commit and this branch