### PR TITLE
Open inline email edit button in a new tab (#476)

### DIFF
--- a/crm/templates/admin/crm/inline_emails.html
+++ b/crm/templates/admin/crm/inline_emails.html
@@ -32,7 +32,7 @@
                     <a href="{% url 'download_original_email' email.id %}" title="{% translate 'Download the original email as an EML file.' %}"><i class="material-icons" style="font-size: 17px;vertical-align: middle;">file_download</i></a>
                   </li>&nbsp;&nbsp;
                 {% endif %}
-                  <li><a href="{%  url 'site:crm_crmemail_change' email.id %}" title="{% translate 'Change' %}"><i class="material-icons" style="font-size: 17px;vertical-align: middle;">border_color</i></a></li>
+                  <li><a href="{% url 'site:crm_crmemail_change' email.id %}" title="{% translate 'Change' %}" target="_blank"><i class="material-icons" style="font-size: 17px;vertical-align: middle;">border_color</i></a></li>
                   <li><a href="{%  url 'reply_email' email.id %}?act=reply" title="{% translate 'reply' %}" target="_blank"><i class="material-icons" style="font-size: 17px;vertical-align: middle;">reply</i></a></li>
                   <li><a href="{%  url 'reply_email' email.id %}?act=reply-all" title="{% translate 'reply all' %}" target="_blank"><i class="material-icons" style="font-size: 17px;vertical-align: middle;">reply_all</i></a></li>
                   <li><a href="{%  url 'reply_email' email.id %}?act=forward" title="{% translate 'forward' %}" target="_blank"><i class="material-icons" style="font-size: 17px;vertical-align: middle;">forward</i></a></li>


### PR DESCRIPTION
Closes #476. Added target="_blank" to the email edit (pencil) link in crm/templates/admin/crm/inline_emails.html so it opens the email edit page in a new tab, consistent with the reply/forward/print buttons in the same action row. Ran the full test suite locally and all 342 tests pass. 