### PR TITLE
fix: show CC for incoming inline emails

### DIFF
--- a/crm/templates/admin/crm/inline_emails.html
+++ b/crm/templates/admin/crm/inline_emails.html
@@ -47,6 +47,11 @@
                 <div class="form-row field-to">
                     <div class="readonly"><b>{% translate 'To' %}:</b> &nbsp{{ email.to }}</div>
                 </div>
+                {% if email.incoming and email.cc %}
+                <div class="form-row field-cc">
+                    <div class="readonly"><b>{% translate 'CC' %}:</b> &nbsp{{ email.cc }}</div>
+                </div>
+                {% endif %}
                 <div class="form-row field-creation_date">
                 <div class="readonly"><b>{% translate 'Date' %}:</b> &nbsp{{ email.creation_date }}</div>
                 </div>

--- a/tests/crm/test_deal.py
+++ b/tests/crm/test_deal.py
@@ -130,6 +130,65 @@ class TestDeal(BaseTestCase):
         response = self.client.get(self.deal_change_url, follow=True)
         self.assertEqual(response.status_code, 200, response.reason_phrase)
 
+    def test_inline_emails_display_cc_only_for_incoming_email(self):
+        visible_cc = 'visible-cc@example.com'
+        hidden_ccs = (
+            'sent-hidden-cc@example.com',
+            'unsent-hidden-cc@example.com',
+        )
+        self.contact_request.owner = self.owner
+        self.contact_request.department = self.department
+        self.contact_request.save(update_fields=['owner', 'department'])
+
+        incoming_email = CrmEmail.objects.get(
+            deal=self.deal,
+            incoming=True,
+        )
+        incoming_email.cc = visible_cc
+        incoming_email.request = self.contact_request
+        incoming_email.save(update_fields=['cc', 'request'])
+
+        for subject, incoming, sent, cc, days_ago in (
+            ('Incoming without CC', True, False, '', 6),
+            ('Sent outgoing with CC', False, True, hidden_ccs[0], 5),
+            ('Unsent outgoing with CC', False, False, hidden_ccs[1], 4),
+        ):
+            CrmEmail.objects.create(
+                to='sale@crm.com',
+                from_field='customer@example.com',
+                subject=subject,
+                content='',
+                incoming=incoming,
+                sent=sent,
+                cc=cc,
+                department=self.department,
+                owner=self.owner,
+                deal=self.deal,
+                request=self.contact_request,
+                is_html=False,
+                creation_date=self.now - timedelta(days=days_ago),
+            )
+
+        for url in (self.deal_change_url,
+                    self.contact_request.get_absolute_url()):
+            with self.subTest(url=url):
+                response = self.client.get(url, follow=True)
+
+                self.assertEqual(
+                    response.status_code, 200, response.reason_phrase
+                )
+                for subject in (
+                    'test inquiry',
+                    'Incoming without CC',
+                    'Sent outgoing with CC',
+                    'Unsent outgoing with CC',
+                ):
+                    self.assertContains(response, subject)
+                self.assertContains(response, 'field-cc', count=1)
+                self.assertContains(response, visible_cc)
+                for hidden_cc in hidden_ccs:
+                    self.assertNotContains(response, hidden_cc)
+
     def test_for_chief(self):
         """
         Test the availability of the fields 'important' and 'translation' for the chief.


### PR DESCRIPTION
## Summary

- show the CC field in the shared inline-email template only for incoming emails with a non-empty value
- cover both Request and Deal pages, including sent and unsent outgoing emails

Closes #447

## Testing

- `python manage.py test tests.crm.test_deal.TestDeal.test_inline_emails_display_cc_only_for_incoming_email --noinput --verbosity 2` — passed (1 test)
- `python manage.py check` — passed
- `python manage.py makemigrations --check --dry-run` — passed, no changes detected
- `python -m compileall -q crm tests` — passed
- `python -m pip check` — passed
- `python manage.py test tests/ --noinput` — 343 tests run; 5 existing `mail.outbox` failures and 4 skips. The same five failing test names reproduce on the clean base commit: the four `TestChat` cases and `TestReminder.test_task_reminder`.

## Pull Request Checklist

- [ ] Tests passed.
- [ ] No testing required.
- [x] The pull request targets a topic branch.
- [x] A descriptive title and description are provided.
- [x] This pull request contains one focused change.
- [x] The changed template and its regression test belong in one pull request.
- [ ] Documentation updated (not needed for this focused UI behavior change).

## When applicable

- [x] The issue number is provided.
- [x] This closes the issue mentioned.
- [ ] Screenshots provided.
- [x] Additional tests have been written.