### PR TITLE
fix: show company logos in contact list

### DIFF
--- a/crm/site/contactadmin.py
+++ b/crm/site/contactadmin.py
@@ -185,4 +185,4 @@ class ContactAdmin(CrmModelAdmin):
         ordering='company'
     )
     def contact_company(self, obj):
-        return obj.company
+        return obj.company.thumbnail_full_name

--- a/tests/crm/test_contact.py
+++ b/tests/crm/test_contact.py
@@ -64,6 +64,20 @@ class TestContact(BaseTestCase):
         self.assertEqual(self.response.status_code, 200,
                          self.response.reason_phrase)
 
+    def test_contact_list_displays_company_name_and_logo(self):
+        self.company.logo = "company_logos/test-logo.png"
+        self.company.save(update_fields=['logo'])
+        Contact.objects.create(
+            **{**self.contact_data, 'company': self.company}
+        )
+
+        response = self.client.get(self.changelist_url)
+
+        self.assertContains(response, "Test company")
+        self.assertContains(
+            response, '<img src="/media/company_logos/test-logo.png"', html=False
+        )
+
     def test_change_contact(self):
         contact_data = self.contact_data.copy()
         contact_data['company'] = self.company


### PR DESCRIPTION
## Summary

I updated the contact list's company column to use the existing company thumbnail renderer. Company names now appear with their uploaded logos, matching the presentation already used on the Requests and Deals pages.

I also added a regression test that renders the contact changelist and verifies both the company name and logo URL.

Fixes #512

## Verification

- `python manage.py test tests.crm.test_contact.TestContact.test_contact_list_displays_company_name_and_logo --noinput --verbosity 2` — passed
- `python manage.py test tests/ --noinput` — 344 tests passed, 4 skipped
- `python manage.py check` — passed
- `python manage.py makemigrations --check --dry-run` — no changes detected
- `python -m compileall -q crm/site/contactadmin.py tests/crm/test_contact.py` — passed
- `git diff --check origin/main...HEAD` — passed

## Pull Request Checklist

- [x] Tests passed.
- [ ] No testing required.
- [x] I am requesting to pull a topic branch.
- [x] I provided a descriptive title and description.
- [x] I included one focused change.
- [x] The changed implementation and regression test belong in one pull request.
- [x] Documentation is up-to-date; no documentation change is needed for this UI consistency fix.

## When applicable

- [x] I provided the issue number.
- [x] This closes the issue mentioned.
- [ ] Screenshots are provided; the rendered changelist behavior is covered by the regression test.
- [x] I added a regression test.
